### PR TITLE
MAINT: stats: qmc distributions should not inherit from QMCEngine

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1742,7 +1742,7 @@ class MultivariateNormalQMC:
             The MultivariateNormalQMC engine itself.
 
         """
-        self.random(n=n)
+        self.engine.fast_forward(n=n)
         return self
 
     def _correlate(self, base_samples: np.ndarray) -> np.ndarray:

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -796,11 +796,6 @@ class TestMultinomialQMC:
         with pytest.raises(ValueError, match=message):
             qmc.MultinomialQMC(p, engine=np.random.default_rng())
 
-        message = r"multinomial distribution is already defined on integers"
-        with pytest.raises(NotImplementedError, match=message):
-            engine = qmc.MultinomialQMC(1)
-            engine.integers(1)
-
     @pytest.mark.filterwarnings('ignore::UserWarning')
     def test_MultinomialBasicDraw(self):
         seed = np.random.default_rng(6955663962957011631562466584467607969)
@@ -1000,11 +995,6 @@ class TestMultivariateNormalQMC:
         message = r"Dimension mismatch between mean and covariance."
         with pytest.raises(ValueError, match=message):
             qmc.MultivariateNormalQMC([0], [[1, 0], [0, 1]])
-
-        message = r"Integers can be drawn from the multivariate normal"
-        with pytest.raises(NotImplementedError, match=message):
-            engine = qmc.MultivariateNormalQMC(0)
-            engine.integers(1)
 
     def test_MultivariateNormalQMCNonPD(self):
         # try with non-pd but psd cov; should work


### PR DESCRIPTION
As I reviewed gh-15946, I felt I had to make this suggestion more thoroughly, so this is just a proof of concept to suggest that QMC distributions should not subclass `QMCEngine`. I don't mean to be contrary; I'm just trying to make the model more sustainable so that `qmc` can grow without this inheritance biting us.

---

There is a certain relationship that `Sobol`, `Halton`, and `LatinHypercube` have with `QMCEngine`: they are all different ways of generating a low discrepancy sequence. That is why it is reasonable to make them subclasses - more specific versions - of a single superclass `QMCEngine`. 

`MultivariateNormalQMC` and `MultinomialQMC` have a very different sort of relationship with `QMCEngine`. They simply transform random variates generated by any `QMCEngine`(any one of the above) to follow some other probability distribution. They certainly _have_ an underlying `QMCEngine`, but they _are not_ themselves methods of generating a low-discrepancy sequence. Even if we want them to have some methods with the same names as those of `QMCEngine`, they are not a more specific type of low-discrepancy sequence generator, so they should not subclass `QMCEngine`.

Under the hood of these distribution classes, almost all actual code reuse is already happening by composition rather than inheritance anyway. (QMC distributions call methods of the underlying `QMCEngine` to do a lot of the work). But then with the addition of `integers`, even that begins to break down: in scipy/gh-15946, the `integers` method had to be overridden to raise `NotImplementedError`. Why not save ourselves the trouble by not inheriting the obligation to implement these unnecessary methods? We still accomplish code reuse via composition, but we reduce the amount of code we have to write to get distribution objects working as desired, we simplify the API without affecting functionality or user convenience, and we follow a more standard design pattern.