### PR TITLE
DOC: stats.levene: corrections [skip cirrus] [skip actions]

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2784,7 +2784,7 @@ def levene(*samples, center='median', proportiontocut=0.05):
     The value of the statistic tends to be high when there is a large
     difference in variances.
 
-    We can test for ineuqality of variance among the groups by comparing the
+    We can test for inequality of variance among the groups by comparing the
     observed value of the statistic against the null distribution: the
     distribution of statistic values derived under the null hypothesis that
     the population variances of the three groups are equal.

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2744,20 +2744,22 @@ def levene(*samples, center='median', proportiontocut=0.05):
            Zero: Calculating Exact P-values When Permutations Are Randomly
            Drawn." Statistical Applications in Genetics and Molecular Biology
            9.1 (2010).
+    .. [6] Ludbrook, J., & Dudley, H. (1998). Why permutation tests are
+           superior to t and F tests in biomedical research. The American
+           Statistician, 52(2), 127-132.
 
     Examples
     --------
     In [4]_, the influence of vitamin C on the tooth growth of guinea pigs
     was investigated. In a control study, 60 subjects were divided into
     small dose, medium dose, and large dose groups that received
-    daily doses of 0.5, 1.0 and 2.0 mg of vitamin C, respectively. 
-    After 42 days, the tooth growth, in microns, was measured.
+    daily doses of 0.5, 1.0 and 2.0 mg of vitamin C, respectively.
+    After 42 days, the tooth growth was measured.
 
-    In the following, we are interested in testing the null hypothesis that all
-    groups are from populations with equal variances.
+    The ``small_dose`, ``medium_dose``, and ``large_dose`` arrays below record
+    tooth growth measurements of the three groups in microns.
 
     >>> import numpy as np
-    >>> from scipy import stats
     >>> small_dose = np.array([
     ...     4.2, 11.5, 7.3, 5.8, 6.4, 10, 11.2, 11.2, 5.2, 7,
     ...     15.2, 21.5, 17.6, 9.7, 14.5, 10, 8.2, 9.4, 16.5, 9.7
@@ -2770,17 +2772,28 @@ def levene(*samples, center='median', proportiontocut=0.05):
     ...     23.6, 18.5, 33.9, 25.5, 26.4, 32.5, 26.7, 21.5, 23.3, 29.5,
     ...     25.5, 26.4, 22.4, 24.5, 24.8, 30.9, 26.4, 27.3, 29.4, 23
     ... ])
+
+    The `levene` statistic is sensitive to differences in variances
+    between the samples.
+
+    >>> from scipy import stats
     >>> res = stats.levene(small_dose, medium_dose, large_dose)
     >>> res.statistic
     0.6457341109631506
 
-    The test is performed by comparing the observed value of the
-    statistic against the null distribution: the distribution of statistic
-    values derived under the null hypothesis that the groups' variances are
-    drawn from a F distribution.
+    The value of the statistic tends to be high when there is a large
+    difference in variances.
+
+    We can test for ineuqality of variance among the groups by comparing the
+    observed value of the statistic against the null distribution: the
+    distribution of statistic values derived under the null hypothesis that
+    the population variances of the three groups are equal.
+
+    For this test, the null distribution follows the F distribution as shown
+    below.
 
     >>> import matplotlib.pyplot as plt
-    >>> k, n = 3, 20   # number of samples, sample size
+    >>> k, n = 3, 60   # number of samples, total number of observations
     >>> dist = stats.f(dfn=k-1, dfd=n-k)
     >>> lev_val = np.linspace(0, 5, 100)
     >>> pdf = dist.pdf(lev_val)
@@ -2799,7 +2812,7 @@ def levene(*samples, center='median', proportiontocut=0.05):
 
     >>> fig, ax = plt.subplots(figsize=(8, 5))
     >>> lev_plot(ax)
-    >>> pvalue = dist.cdf(-res.statistic) + dist.sf(res.statistic)
+    >>> pvalue = dist.sf(res.statistic)
     >>> annotation = (f'p-value={pvalue:.3f}\n(shaded area)')
     >>> props = dict(facecolor='black', width=1, headwidth=5, headlength=8)
     >>> _ = ax.annotate(annotation, (1.5, 0.22), (2.25, 0.3), arrowprops=props)
@@ -2812,10 +2825,10 @@ def levene(*samples, center='median', proportiontocut=0.05):
     0.5280694573759905
 
     If the p-value is "small" - that is, if there is a low probability of
-    sampling data from a F distributed population that produces such an
-    extreme value of the statistic - this may be taken as evidence against
-    the null hypothesis in favor of the alternative: the variances were not
-    drawn from a F distribution. Note that:
+    sampling data from distributions with identical variances that produces
+    such an extreme value of the statistic - this may be taken as evidence
+    against the null hypothesis in favor of the alternative: the variances of
+    the groups are not equal. Note that:
 
     - The inverse is not true; that is, the test is not used to provide
       evidence for the null hypothesis.
@@ -2823,13 +2836,19 @@ def levene(*samples, center='median', proportiontocut=0.05):
       should be made before the data is analyzed [5]_ with consideration of the
       risks of both false positives (incorrectly rejecting the null hypothesis)
       and false negatives (failure to reject a false null hypothesis).
+    - Small p-values are not evidence for a *large* effect; rather, they can
+      only provide evidence for a "significant" effect, meaning that they are
+      unlikely to have occurred under the null hypothesis.
 
     Note that the F distribution provides an asymptotic approximation of the
     null distribution; it is only accurate for samples with many observations.
     For small samples, it may be more appropriate to perform a permutation
-    test: Under the null hypothesis that all samples are drawn from populations
-    with the same variance. Therefore, we can form an *exact* null distribution
-    by calculating the statistic from the independent samples.
+    test: Under the null hypothesis that all three samples were drawn from
+    the same population, each of the measurements is equally likely to have
+    been observed in any of the three samples. Therefore, we can form a
+    randomized null distribution by calculating the statistic under many
+    randomly-generated partitionings of the observations into the three
+    samples.
 
     >>> def statistic(*samples):
     ...     return stats.levene(*samples).statistic
@@ -2844,17 +2863,18 @@ def levene(*samples, center='median', proportiontocut=0.05):
     ...     ref.null_distribution, bins=bins, density=True, facecolor="C1"
     ... )
     >>> ax.legend(['aymptotic approximation\n(many observations)',
-    ...            'exact null distribution'])
+    ...            'randomized null distribution'])
     >>> lev_plot(ax)
     >>> plt.show()
 
-     >>> ref.pvalue
-    0.4559  # exact p-value
+     >>> ref.pvalue  # randomized test p-value
+    0.4559  # may vary
 
-    Note that there is significant disagreement between the exact p-value
-    calculated here and the approximation returned by `levene` above. For small
-    samples with ties, consider performing a permutation test for more
-    accurate results.
+    Note that there is significant disagreement between the p-value calculated
+    here and the asymptotic approximation returned by `levene` above.
+    The statistical inferences that can be drawn rigorously from a permutation
+    test are limited; nonetheless, they may be the preferred approach in many
+    circumstances [6]_.
 
     Following is another generic example where the null hypothesis would be
     rejected.


### PR DESCRIPTION
This makes some technical corrections about the description of the test. I also altered it to more closely follow the template of the Pearson example, which we seemed to agree on.

It doesn't fix the lint issues and may introduce more. Note that the example is not appearing in the rendered documentation of gh-17778 for some reason; I didn't debug that.