### PR TITLE
TST: namespace preservation

### DIFF
--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -243,7 +243,12 @@ def _get_mem_available():
     return None
 
 
-def _assert_matching_namespace(a, b):
-    a_space = array_api_compat.array_namespace(a)
-    b_space = array_api_compat.array_namespace(b)
-    assert a_space == b_space
+def _assert_matching_namespace(actual, expected):
+    expected_space = array_api_compat.array_namespace(expected)
+    if isinstance(actual, tuple):
+        for arr in actual:
+            arr_space = array_api_compat.array_namespace(arr)
+            assert arr_space == expected_space
+    else:
+        actual_space = array_api_compat.array_namespace(actual)
+        assert actual_space == expected_space

--- a/scipy/_lib/_testutils.py
+++ b/scipy/_lib/_testutils.py
@@ -8,6 +8,7 @@ import re
 import sys
 import numpy as np
 import inspect
+import array_api_compat
 
 
 __all__ = ['PytestTester', 'check_free_memory', '_TestPythranFunc']
@@ -240,3 +241,9 @@ def _get_mem_available():
             return info['memfree'] + info['cached']
 
     return None
+
+
+def _assert_matching_namespace(a, b):
+    a_space = array_api_compat.array_namespace(a)
+    b_space = array_api_compat.array_namespace(b)
+    assert a_space == b_space

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -12,6 +12,8 @@ from scipy.fft import fftfreq
 from scipy.signal import (periodogram, welch, lombscargle, csd, coherence,
                           spectrogram, stft, istft, check_COLA, check_NOLA)
 from scipy.signal._spectral_py import _spectral_helper
+from scipy.conftest import array_api_compatible
+from scipy._lib._testutils import _assert_matching_namespace
 
 
 class TestPeriodogram:
@@ -236,8 +238,9 @@ class TestPeriodogram:
 
 
 class TestWelch:
-    def test_real_onesided_even(self):
-        x = np.zeros(16)
+    @array_api_compatible
+    def test_real_onesided_even(self, xp):
+        x = xp.zeros(16)
         x[0] = 1
         x[8] = 1
         f, p = welch(x, nperseg=8)
@@ -245,6 +248,8 @@ class TestWelch:
         q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
+        _assert_matching_namespace(f, x)
+        _assert_matching_namespace(p, x)
 
     def test_real_onesided_odd(self):
         x = np.zeros(16)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -248,8 +248,7 @@ class TestWelch:
         q = np.array([0.08333333, 0.15277778, 0.22222222, 0.22222222,
                       0.11111111])
         assert_allclose(p, q, atol=1e-7, rtol=1e-7)
-        _assert_matching_namespace(f, x)
-        _assert_matching_namespace(p, x)
+        _assert_matching_namespace((f, p), x)
 
     def test_real_onesided_odd(self):
         x = np.zeros(16)


### PR DESCRIPTION
* a sample of namespace preservation testing from my work with `welch()`

* if `test_real_onesided_even()` is only decorated with `array_api_compatible` it will pass, but the namespace checking causes it to fail -- this is because some types of assertion checking with host array types can be automatically coerced to compatible arrays/data

* I've tried to keep this as simple as possible--only porting over a subset of changes to just 1 test for now, and none of the actual `scipy.signal` shims just yet, to facilitate review...