### PR TITLE
WIP: ENH: fft: support Array API, see #26 [Design 2]

### DIFF
--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -1,3 +1,5 @@
+from scipy._lib._array_api import as_xparray, array_namespace
+from . import _pocketfft as pocketfft
 from scipy._lib.uarray import generate_multimethod, Dispatchable
 import numpy as np
 
@@ -20,9 +22,33 @@ def _dispatch(func):
     return generate_multimethod(func, _x_replacer, domain="numpy.scipy.fft")
 
 
-@_dispatch
 def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         plan=None):
+    """
+    For non-numpy arrays, this implements the Array API specification of fft.
+    For numpy arrays, see the documentation for npfft.fft.
+    Note that if arguments outside of those in the Array API specification
+    are provided with a non-numpy array, an exception is raised.
+    """
+    if isinstance(x, np.ndarray):
+        return _np_fft(x, n, axis, norm, overwrite_x, workers, plan)
+    if overwrite_x is not False:
+        Exception
+    if workers is not None:
+        Exception
+    if plan is not None:
+        Exception
+    xp = array_namespace(x)
+    if hasattr(xp, 'fft'):
+        return xp.fft.fft(x, n, axis, norm)
+    x = np.asarray(x)
+    y = pocketfft.fft(x, n, axis, norm)
+    return xp.asarray(y)
+
+
+@_dispatch
+def _np_fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
+            plan=None):
     """
     Compute the 1-D discrete Fourier Transform.
 


### PR DESCRIPTION
### Reference issue
see #26 

### What is this working to implement?
`scipy.fft` currently works on the assumption that its inputs are NumPy arrays. Passing in non-NumPy arrays can cause errors, e.g. (where `scipy` is imported as `sp` and `cupy` is imported as `cp`)
```
>>> sp.fft.fft(cp.exp(2j * cp.pi * cp.arange(8) / 8))
[...]
KeyError: 'ALIGNED is not defined for cupy.ndarray.flags'
```

In order to make `scipy.fft` conform to the Array API standard, this solution aims to deal with NumPy arrays and non-NumPy arrays separately, and for non-NumPy arrays which already implement `fft`, to use their implementation. This is visualised for `scipy.fft.fft` in this diagram:
![image](https://github.com/tupui/scipy/assets/51488791/85d449ac-7450-4236-938e-d9d11811f3af)

This PR proposes to rename the current functions and replace them with new functions to handle all required array types. The new functions would be written to match the SciPy API and would call the renamed functions in the case of a NumPy array.

### What is the current progress?

The commit that comes with this PR demonstrates how an implementation with this design option may work, with the example of `scipy.fft.fft`.

**What works?** Non-NumPy arrays which implement `fft` now seem to be handled correctly (based on some manual testing with CuPy arrays).

**What is broken?** NumPy arrays now error out since there is no backend function to for `_np_fft` to dispatch to. Perhaps this can be fixed by changing details of the `uarray` dispatch structure, but this may mean that this design option is not ideal.

**What may be working but hasn't been tested?** The handling of non-NumPy arrays which do not implement `fft`. The design in this case is to (attempt to) convert to a NumPy array, use the `_pocketfft` subpackage, then convert back to the original type.