### PR TITLE
Search theme

### DIFF
--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -185,3 +185,8 @@ div.admonition-legacy {
 .admonition-legacy.admonition > .admonition-title:after {
   background-color: var(--pst-color-warning);
 }
+
+/* extra breathing room for logo image */
+.navbar-brand.logo {
+    margin-right: 0.5rem;
+}

--- a/doc/source/_templates/sidebar-nav-bs.html
+++ b/doc/source/_templates/sidebar-nav-bs.html
@@ -5,7 +5,7 @@
     {% if pagename.startswith("reference") %}
       {{- generate_toctree_html("sidebar", maxdepth=1, collapse=True, includehidden=True, titles_only=True) -}}
     {% else %}
-      {{- generate_toctree_html("sidebar", maxdepth=2, collapse=True, includehidden=True, titles_only=True) -}}
+      {{- generate_toctree_html("sidebar", maxdepth=2, collapse=True, includehidden=False, titles_only=True) -}}
     {% endif %}
   </div>
 </nav>

--- a/doc/source/_templates/sidebar-nav-bs.html
+++ b/doc/source/_templates/sidebar-nav-bs.html
@@ -1,0 +1,11 @@
+{# Displays the TOC-subtree for pages nested under the currently active top-level TOCtree element. #}
+<nav class="bd-docs-nav bd-links" aria-label="{{ _('Section Navigation') }}">
+  <p class="bd-links__title" role="heading" aria-level="1">{{ _("Section Navigation") }}</p>
+  <div class="bd-toc-item navbar-nav">
+    {% if pagename.startswith("reference") %}
+      {{- generate_toctree_html("sidebar", maxdepth=1, collapse=True, includehidden=True, titles_only=True) -}}
+    {% else %}
+      {{- generate_toctree_html("sidebar", maxdepth=2, collapse=True, includehidden=True, titles_only=True) -}}
+    {% endif %}
+  </div>
+</nav>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -211,7 +211,6 @@ html_theme_options = {
   "icon_links": [],
   "navbar_start": ["navbar-logo", "version-switcher"],
   "navbar_persistent": [],
-  "navigation_depth": 1,
   "switcher": {
       "json_url": "https://scipy.github.io/devdocs/_static/version_switcher.json",
       "version_match": version,


### PR DESCRIPTION
with these changes plus https://github.com/pydata/pydata-sphinx-theme/pull/1632 at `867dac1`, I'm getting local builds around 13 minutes (single threaded) with correct left sidebar TocTrees on all pages.